### PR TITLE
Add package description to the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "nealio82/avro-php",
+  "description": "Implementation of Apache's Avro PHP library with Composer support, PSR-4 autoloading, namespaces, and type hinted method parameters",
   "autoload": {
     "psr-4" : {
       "Avro\\": "src/Avro"


### PR DESCRIPTION
Missing package description makes it harder for Packagist to see what's going on