### PR TITLE
make documentation less messy. fix old redundant class names. fix sho…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,33 @@ use Avro\Schema\Schema;
 require_once('vendor/autoload.php');
 
 $writers_schema_json = <<<_JSON
-{"name":"member",
+{
+ "name":"member",
  "type":"record",
- "fields":[{"name":"member_id", "type":"int"},
-           {"name":"member_name", "type":"string"}]}
+ "fields":
+    [
+        {"name":"member_id", "type":"int"},
+        {"name":"member_name", "type":"string"}
+    ]
+}
 _JSON;
+
 $jose = array('member_id' => 1392, 'member_name' => 'Jose');
 $maria = array('member_id' => 1642, 'member_name' => 'Maria');
 $data = array($jose, $maria);
+
+
 $file_name = 'data.avr';
+
 // Open $file_name for writing, using the given writer's schema
 $data_writer = DataIO::open_file($file_name, 'w', $writers_schema_json);
 // Write each datum to the file
 foreach ($data as $datum) {
     $data_writer->append($datum);
 }
-// Tidy up
 $data_writer->close();
+
+
 // Open $file_name (by default for reading) using the writer's schema
 // included in the file
 $data_reader = DataIO::open_file($file_name);
@@ -58,14 +68,11 @@ foreach ($data_reader->data() as $datum) {
 $data_reader->close();
 
 
-// Create a data string
-// Create a string io object.
 $io = new StringIO();
 
-// Create a datum writer object
 $writers_schema = Schema::parse($writers_schema_json);
-$writer = new IODatumWriter($writers_schema);
-$data_writer = new DataIOWriter($io, $writer, $writers_schema);
+$data_writer = new DataIOWriter($io, new IODatumWriter($writers_schema), $writers_schema);
+
 foreach ($data as $datum) {
     $data_writer->append($datum);
 }

--- a/src/Avro/Avro.php
+++ b/src/Avro/Avro.php
@@ -2,6 +2,9 @@
 
 namespace Avro;
 
+use Avro\Debug\Debug;
+use Avro\Exception\Exception;
+
 class Avro
 {
     /**
@@ -56,7 +59,7 @@ class Avro
     /**
      * Determines if the host platform can encode and decode long integer data.
      *
-     * @throws AvroException if the platform cannot handle long integers.
+     * @throws Exception if the platform cannot handle long integers.
      */
     private static function check_64_bit()
     {
@@ -64,7 +67,7 @@ class Avro
             if (extension_loaded('gmp'))
                 self::$biginteger_mode = self::GMP_BIGINTEGER_MODE;
             else
-                throw new AvroException('This platform cannot handle a 64-bit operations. '
+                throw new Exception('This platform cannot handle a 64-bit operations. '
                     . 'Please install the GMP PHP extension.');
         else
             self::$biginteger_mode = self::PHP_BIGINTEGER_MODE;
@@ -85,12 +88,12 @@ class Avro
      * Determines if the host platform is little endian,
      * required for processing double and float data.
      *
-     * @throws AvroException if the platform is not little endian.
+     * @throws Exception if the platform is not little endian.
      */
     private static function check_little_endian()
     {
         if (!self::is_little_endian_platform())
-            throw new AvroException('This is not a little-endian platform');
+            throw new Exception('This is not a little-endian platform');
     }
 
     /**
@@ -99,7 +102,7 @@ class Avro
      *
      * Based on a similar check perfomed in http://pear.php.net/package/Math_BinaryUtils
      *
-     * @throws AvroException if the endianness cannot be determined.
+     * @throws Exception if the endianness cannot be determined.
      */
     private static function set_endianness()
     {
@@ -112,9 +115,9 @@ class Avro
                 self::$endianness = self::LITTLE_ENDIAN;
                 break;
             default:
-                throw new AvroException(
+                throw new Exception(
                     sprintf('Error determining platform endianness: %s',
-                        AvroDebug::hex_string($packed)));
+                        Debug::hex_string($packed)));
         }
     }
 

--- a/src/Avro/DataIO/DataIO.php
+++ b/src/Avro/DataIO/DataIO.php
@@ -4,6 +4,7 @@ namespace Avro\DataIO;
 
 use Avro\Datum\IODatumReader;
 use Avro\Datum\IODatumWriter;
+use Avro\Exception\DataIoException;
 use Avro\IO\File;
 use Avro\IO\IO;
 use Avro\Schema\Schema;
@@ -65,13 +66,19 @@ class DataIO
     /**
      * @returns the initial "magic" segment of an Avro container file header.
      */
-    public static function magic() { return ('Obj' . pack('c', self::VERSION)); }
+    public static function magic()
+    {
+        return ('Obj' . pack('c', self::VERSION));
+    }
 
     /**
      * @returns int count of bytes in the initial "magic" segment of the
      *              Avro container file header
      */
-    public static function magic_size() { return strlen(self::magic()); }
+    public static function magic_size()
+    {
+        return strlen(self::magic());
+    }
 
 
     /**
@@ -79,32 +86,33 @@ class DataIO
      */
     public static function metadata_schema()
     {
-        if (is_null(self::$metadata_schema))
+        if (is_null(self::$metadata_schema)) {
             self::$metadata_schema = Schema::parse(self::METADATA_SCHEMA_JSON);
+        }
         return self::$metadata_schema;
     }
 
     /**
      * @param string $file_path file_path of file to open
-     * @param string $mode one of AvroFile::READ_MODE or AvroFile::WRITE_MODE
+     * @param string $mode one of File::READ_MODE or File::WRITE_MODE
      * @param string $schema_json JSON of writer's schema
-     * @returns DataIOWriter instance of AvroDataIOWriter
+     * @returns DataIOWriter instance of DataIOWriter
      *
-     * @throws AvroDataIOException if $writers_schema is not provided
+     * @throws DataIOException if $writers_schema is not provided
      *         or if an invalid $mode is given.
      */
-    public static function open_file($file_path, $mode=File::READ_MODE,
-                                     $schema_json=null)
+    public static function open_file($file_path, $mode = File::READ_MODE,
+                                     $schema_json = null)
     {
         $schema = !is_null($schema_json)
             ? Schema::parse($schema_json) : null;
 
         $io = false;
-        switch ($mode)
-        {
+        switch ($mode) {
             case File::WRITE_MODE:
-                if (is_null($schema))
-                    throw new AvroDataIOException('Writing an Avro file requires a schema.');
+                if (is_null($schema)) {
+                    throw new DataIOException('Writing an Avro file requires a schema.');
+                }
                 $file = new File($file_path, File::WRITE_MODE);
                 $io = self::open_writer($file, $schema);
                 break;
@@ -113,7 +121,7 @@ class DataIO
                 $io = self::open_reader($file, $schema);
                 break;
             default:
-                throw new AvroDataIOException(
+                throw new DataIOException(
                     sprintf("Only modes '%s' and '%s' allowed. You gave '%s'.",
                         File::READ_MODE, File::WRITE_MODE, $mode));
         }

--- a/src/Avro/DataIO/DataIOReader.php
+++ b/src/Avro/DataIO/DataIOReader.php
@@ -11,7 +11,7 @@ use Avro\Util\Util;
 
 /**
  *
- * Reads Avro data from an AvroIO source using an AvroSchema.
+ * Reads Avro data from an IO source using an AvroSchema.
  * @package Avro
  */
 class DataIOReader
@@ -50,14 +50,15 @@ class DataIOReader
      * @param IO $io source from which to read
      * @param IODatumReader $datum_reader reader that understands
      *                                        the data schema
-     * @throws DataIoException if $io is not an instance of AvroIO
+     * @throws DataIoException if $io is not an instance of IO
      * @uses read_header()
      */
     public function __construct(IO $io, IODatumReader $datum_reader)
     {
 
-        if (!($io instanceof IO))
-            throw new DataIoException('io must be instance of AvroIO');
+        if (!($io instanceof IO)) {
+            throw new DataIoException('io must be instance of IO');
+        }
 
         $this->io = $io;
         $this->decoder = new IOBinaryDecoder($this->io);
@@ -66,8 +67,9 @@ class DataIOReader
 
         $codec = Util::array_value($this->metadata,
             DataIO::METADATA_CODEC_ATTR);
-        if ($codec && !DataIO::is_valid_codec($codec))
+        if ($codec && !DataIO::is_valid_codec($codec)) {
             throw new DataIoException(sprintf('Uknown codec: %s', $codec));
+        }
 
         $this->block_count = 0;
         // FIXME: Seems unsanitary to set writers_schema here.
@@ -90,11 +92,12 @@ class DataIOReader
             throw new DataIoException(
                 'Not an Avro data file: shorter than the Avro magic block');
 
-        if (DataIO::magic() != $magic)
+        if (DataIO::magic() != $magic) {
 
             throw new DataIoException(
                 sprintf('Not an Avro data file: %s does not match %s',
                     $magic, DataIO::magic()));
+        }
 
         $this->metadata = $this->datum_reader->read_data(DataIO::metadata_schema(),
             DataIO::metadata_schema(),
@@ -129,7 +132,7 @@ class DataIOReader
     }
 
     /**
-     * Closes this writer (and its AvroIO object.)
+     * Closes this writer (and its IO object.)
      * @uses IO::close()
      */
     public function close()

--- a/src/Avro/DataIO/DataIOWriter.php
+++ b/src/Avro/DataIO/DataIOWriter.php
@@ -3,7 +3,9 @@
 namespace Avro\DataIO;
 
 use Avro\Datum\IOBinaryEncoder;
+use Avro\Datum\IODatumReader;
 use Avro\Datum\IODatumWriter;
+use Avro\Exception\DataIoException;
 use Avro\IO\IO;
 use Avro\IO\StringIO;
 use Avro\Schema\Schema;
@@ -51,7 +53,7 @@ class DataIOWriter
     /**
      * @var IOBinaryEncoder encoder for buffer
      */
-    private $buffer_encoder; // AvroIOBinaryEncoder
+    private $buffer_encoder; // IOBinaryEncoder
 
     /**
      * @var int count of items written to block
@@ -70,8 +72,9 @@ class DataIOWriter
      */
     public function __construct(IO $io, IODatumWriter $datum_writer, Schema $writers_schema = null)
     {
-        if (!($io instanceof IO))
-            throw new AvroDataIOException('io must be instance of AvroIO');
+        if (!($io instanceof IO)) {
+            throw new DataIOException('io must be instance of IO');
+        }
 
         $this->io = $io;
         $this->encoder = new IOBinaryEncoder($this->io);
@@ -87,7 +90,7 @@ class DataIOWriter
             $this->metadata[DataIO::METADATA_SCHEMA_ATTR] = strval($writers_schema);
             $this->write_header();
         } else {
-            $dataIOReader = new DataIOReader($this->io, new AvroIODatumReader());
+            $dataIOReader = new DataIOReader($this->io, new IODatumReader());
             $this->sync_marker = $dataIOReader->getSyncMarker();
             $this->metadata[DataIO::METADATA_CODEC_ATTR] = $dataIOReader->getMetaDataFor(DataIO::METADATA_CODEC_ATTR);
 
@@ -111,7 +114,7 @@ class DataIOWriter
     }
 
     /**
-     * Flushes buffer to AvroIO object container and closes it.
+     * Flushes buffer to IO object container and closes it.
      * @return mixed value of $io->close()
      * @see IO::close()
      */
@@ -122,7 +125,7 @@ class DataIOWriter
     }
 
     /**
-     * Flushes biffer to AvroIO object container.
+     * Flushes buffer to IO object container.
      * @returns mixed value of $io->flush()
      * @see IO::flush()
      */
@@ -133,8 +136,8 @@ class DataIOWriter
     }
 
     /**
-     * Writes a block of data to the AvroIO object container.
-     * @throws AvroDataIOException if the codec provided by the encoder
+     * Writes a block of data to the IO object container.
+     * @throws DataIOException if the codec provided by the encoder
      *         is not supported
      * @internal Should the codec check happen in the constructor?
      *           Why wait until we're writing data?
@@ -151,7 +154,7 @@ class DataIOWriter
             )
                 $this->write($to_write);
             else
-                throw new AvroDataIOException(
+                throw new DataIOException(
                     sprintf('codec %s is not supported',
                         $this->metadata[DataIO::METADATA_CODEC_ATTR]));
 
@@ -162,7 +165,7 @@ class DataIOWriter
     }
 
     /**
-     * Writes the header of the AvroIO object container
+     * Writes the header of the IO object container
      */
     private function write_header()
     {

--- a/src/Avro/Datum/IOBinaryDecoder.php
+++ b/src/Avro/Datum/IOBinaryDecoder.php
@@ -7,7 +7,7 @@ use Avro\GMP\GMP;
 use Avro\IO\IO;
 
 /**
- * Decodes and reads Avro data from an AvroIO object encoded using
+ * Decodes and reads Avro data from an IO object encoded using
  * Avro binary encoding.
  *
  * @package Avro
@@ -37,7 +37,7 @@ class IOBinaryDecoder
      * Performs decoding of the binary string to a float value.
      *
      * XXX: This is <b>not</b> endian-aware! See comments in
-     * {@link AvroIOBinaryEncoder::float_to_int_bits()} for details.
+     * {@link IOBinaryEncoder::float_to_int_bits()} for details.
      *
      * @param string $bits
      * @returns float
@@ -52,7 +52,7 @@ class IOBinaryDecoder
      * Performs decoding of the binary string to a double value.
      *
      * XXX: This is <b>not</b> endian-aware! See comments in
-     * {@link AvroIOBinaryEncoder::float_to_int_bits()} for details.
+     * {@link IOBinaryEncoder::float_to_int_bits()} for details.
      *
      * @param string $bits
      * @returns float
@@ -79,7 +79,7 @@ class IOBinaryDecoder
 
     /**
      * @returns string the next byte from $this->io.
-     * @throws AvroException if the next byte cannot be read.
+     * @throws Exception if the next byte cannot be read.
      */
     private function next_byte()
     {
@@ -225,7 +225,7 @@ class IOBinaryDecoder
     }
 
     /**
-     * @returns int position of pointer in AvroIO instance
+     * @returns int position of pointer in IO instance
      * @uses IO::tell()
      */
     private function tell()

--- a/src/Avro/Datum/IOBinaryEncoder.php
+++ b/src/Avro/Datum/IOBinaryEncoder.php
@@ -3,10 +3,11 @@
 namespace Avro\Datum;
 
 use Avro\Avro;
+use Avro\GMP\GMP;
 use Avro\IO\IO;
 
 /**
- * Encodes and writes Avro data to an AvroIO object using
+ * Encodes and writes Avro data to an IO object using
  * Avro binary encoding.
  *
  * @package Avro
@@ -17,7 +18,7 @@ class IOBinaryEncoder
      * Performs encoding of the given float value to a binary string
      *
      * XXX: This is <b>not</b> endian-aware! The {@link Avro::check_platform()}
-     * called in {@link AvroIOBinaryEncoder::__construct()} should ensure the
+     * called in {@link IOBinaryEncoder::__construct()} should ensure the
      * library is only used on little-endian platforms, which ensure the little-endian
      * encoding required by the Avro spec.
      *
@@ -34,7 +35,7 @@ class IOBinaryEncoder
      * Performs encoding of the given double value to a binary string
      *
      * XXX: This is <b>not</b> endian-aware! See comments in
-     * {@link AvroIOBinaryEncoder::float_to_int_bits()} for details.
+     * {@link IOBinaryEncoder::float_to_int_bits()} for details.
      *
      * @param double $double
      * @returns string bytes
@@ -108,7 +109,7 @@ class IOBinaryEncoder
     function write_long($n)
     {
         if (Avro::uses_gmp())
-            $this->write(AvroGMP::encode_long($n));
+            $this->write(GMP::encode_long($n));
         else
             $this->write(self::encode_long($n));
     }

--- a/src/Avro/Datum/IODatumWriter.php
+++ b/src/Avro/Datum/IODatumWriter.php
@@ -2,6 +2,7 @@
 
 namespace Avro\Datum;
 
+use Avro\Exception\Exception;
 use Avro\Exception\IOTypeException;
 use Avro\Schema\Schema;
 
@@ -73,7 +74,7 @@ class IODatumWriter
             case Schema::UNION_SCHEMA:
                 return $this->write_union($writers_schema, $datum, $encoder);
             default:
-                throw new AvroException(sprintf('Uknown type: %s',
+                throw new Exception(sprintf('Uknown type: %s',
                     $writers_schema->type));
         }
     }

--- a/src/Avro/Debug/Debug.php
+++ b/src/Avro/Debug/Debug.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Avro\Debug;
+use Avro\Exception\Exception;
 
 /**
  * Avro library code debugging functions
@@ -115,7 +116,7 @@ class Debug
     static function ascii_array($str, $format = 'ctrl')
     {
         if (!in_array($format, array('ctrl', 'hex', 'dec')))
-            throw new AvroException('Unrecognized format specifier');
+            throw new Exception('Unrecognized format specifier');
 
         $ctrl_chars = array('NUL', 'SOH', 'STX', 'ETX', 'EOT', 'ENQ', 'ACK', 'BEL',
             'BS', 'HT', 'LF', 'VT', 'FF', 'CR', 'SO', 'SI',

--- a/src/Avro/Exception/IOException.php
+++ b/src/Avro/Exception/IOException.php
@@ -3,7 +3,7 @@
 namespace Avro\Exception;
 
 /**
- * Exceptions associated with AvroIO instances.
+ * Exceptions associated with IO instances.
  * @package Avro
  */
 class IOException extends Exception

--- a/src/Avro/Exception/IOSchemaMatchException.php
+++ b/src/Avro/Exception/IOSchemaMatchException.php
@@ -11,8 +11,9 @@ namespace Avro\Exception;
 class IOSchemaMatchException extends Exception
 {
     /**
-     * @param AvroSchema $writers_schema
-     * @param AvroSchema $readers_schema
+     * IOSchemaMatchException constructor.
+     * @param string $writers_schema
+     * @param int $readers_schema
      */
     function __construct($writers_schema, $readers_schema)
     {

--- a/src/Avro/Exception/IOTypeException.php
+++ b/src/Avro/Exception/IOTypeException.php
@@ -9,9 +9,11 @@ namespace Avro\Exception;
  */
 class IOTypeException extends Exception
 {
+
     /**
-     * @param AvroSchema $expected_schema
-     * @param mixed $datum
+     * IOTypeException constructor.
+     * @param string $expected_schema
+     * @param int $datum
      */
     public function __construct($expected_schema, $datum)
     {

--- a/src/Avro/IO/File.php
+++ b/src/Avro/IO/File.php
@@ -5,7 +5,7 @@ namespace Avro\IO;
 use Avro\Exception\IOException;
 
 /**
- * AvroIO wrapper for PHP file access functions
+ * IO wrapper for PHP file access functions
  * @package Avro
  */
 class File extends IO
@@ -26,7 +26,7 @@ class File extends IO
     private $file_path;
 
     /**
-     * @var resource file handle for AvroFile instance
+     * @var resource file handle for File instance
      */
     private $file_handle;
 
@@ -89,13 +89,14 @@ class File extends IO
 
     /**
      * @returns int current position within the file
-     * @throws AvroFileExcpetion if tell failed.
+     * @throws FileExcpetion if tell failed.
      */
     public function tell()
     {
         $position = ftell($this->file_handle);
-        if (false === $position)
+        if (false === $position) {
             throw new IOException('Could not execute tell on reader');
+        }
         return $position;
     }
 

--- a/src/Avro/IO/IO.php
+++ b/src/Avro/IO/IO.php
@@ -36,7 +36,7 @@ class IO
     const SEEK_END = SEEK_END;
 
     /**
-     * Read $len bytes from AvroIO instance
+     * Read $len bytes from IO instance
      * @var int $len
      * @return string bytes read
      */
@@ -49,7 +49,7 @@ class IO
      * Append bytes to this buffer. (Nothing more is needed to support Avro.)
      * @param str $arg bytes to write
      * @returns int count of bytes written.
-     * @throws AvroIOException if $args is not a string value.
+     * @throws IOException if $args is not a string value.
      */
     public function write($arg)
     {
@@ -57,7 +57,7 @@ class IO
     }
 
     /**
-     * Return byte offset within AvroIO instance
+     * Return byte offset within IO instance
      * @return int
      */
     public function tell()
@@ -75,7 +75,7 @@ class IO
      *                    or Avro::SEEK_END
      * @returns boolean true
      *
-     * @throws AvroIOException
+     * @throws IOException
      */
     public function seek($offset, $whence=self::SEEK_SET)
     {
@@ -83,7 +83,7 @@ class IO
     }
 
     /**
-     * Flushes any buffered data to the AvroIO object.
+     * Flushes any buffered data to the IO object.
      * @returns boolean true upon success.
      */
     public function flush()
@@ -92,7 +92,7 @@ class IO
     }
 
     /**
-     * Returns whether or not the current position at the end of this AvroIO
+     * Returns whether or not the current position at the end of this IO
      * instance.
      *
      * Note is_eof() is <b>not</b> like eof in C or feof in PHP:
@@ -106,7 +106,7 @@ class IO
     }
 
     /**
-     * Closes this AvroIO instance.
+     * Closes this IO instance.
      */
     public function close()
     {

--- a/src/Avro/IO/StringIO.php
+++ b/src/Avro/IO/StringIO.php
@@ -5,7 +5,7 @@ namespace Avro\IO;
 use Avro\Exception\IOException;
 
 /**
- * AvroIO wrapper for string access
+ * IO wrapper for string access
  * @package Avro
  */
 class StringIO extends IO
@@ -24,7 +24,7 @@ class StringIO extends IO
     private $is_closed;
 
     /**
-     * @param string $str initial value of AvroStringIO buffer. Regardless
+     * @param string $str initial value of StringIO buffer. Regardless
      *                    of the initial value, the pointer is set to the
      *                    beginning of the buffer.
      * @throws IOException if a non-string value is passed as $str
@@ -35,11 +35,12 @@ class StringIO extends IO
         $this->string_buffer = '';
         $this->current_index = 0;
 
-        if (is_string($str))
+        if (is_string($str)) {
             $this->string_buffer .= $str;
-        else
+        } else {
             throw new IOException(
                 sprintf('constructor argument must be a string: %s', gettype($str)));
+        }
     }
 
     /**
@@ -128,7 +129,7 @@ class StringIO extends IO
     }
 
     /**
-     * No-op provided for compatibility with AvroIO interface.
+     * No-op provided for compatibility with IO interface.
      * @returns boolean true
      */
     public function flush()
@@ -152,8 +153,9 @@ class StringIO extends IO
      */
     private function check_closed()
     {
-        if ($this->is_closed())
+        if ($this->is_closed()) {
             throw new IOException('Buffer is closed');
+        }
     }
 
     /**

--- a/src/Avro/Protocol/Protocol.php
+++ b/src/Avro/Protocol/Protocol.php
@@ -4,6 +4,7 @@ namespace Avro\Protocol;
 
 use Avro\Exception\ProtocolParseException;
 use Avro\Schema\NamedSchemata;
+use Avro\Schema\Schema;
 
 /**
  * Avro library for protocols
@@ -33,7 +34,7 @@ class Protocol
         $this->name = $avro["protocol"];
 
         if (!is_null($avro["types"])) {
-            $types = AvroSchema::real_parse($avro["types"], $this->namespace, $this->schemata);
+            $types = Schema::real_parse($avro["types"], $this->namespace, $this->schemata);
         }
 
         if (!is_null($avro["messages"])) {

--- a/src/Avro/Protocol/ProtocolMessage.php
+++ b/src/Avro/Protocol/ProtocolMessage.php
@@ -24,7 +24,7 @@ class ProtocolMessage
         if (array_key_exists('response', $avro)) {
             $this->response = $protocol->schemata->schema_by_name(new Name($avro{'response'}, $protocol->namespace, $protocol->namespace));
             if ($this->response == null)
-                $this->response = new AvroPrimitiveSchema($avro{'response'});
+                $this->response = new PrimitiveSchema($avro{'response'});
         }
     }
 }

--- a/src/Avro/Schema/ArraySchema.php
+++ b/src/Avro/Schema/ArraySchema.php
@@ -10,20 +10,19 @@ namespace Avro\Schema;
 class ArraySchema extends Schema
 {
     /**
-     * @var Name|Schema named schema name or AvroSchema of
-     *                          array element
+     * @var Name|Schema named schema name or Schema of array element
      */
     private $items;
 
     /**
      * @var boolean true if the items schema
      * FIXME: couldn't we derive this from whether or not $this->items
-     *        is an AvroName or an AvroSchema?
+     *        is an Name or an Schema?
      */
     private $is_items_schema_from_schemata;
 
     /**
-     * @param string|mixed $items AvroNamedSchema name or object form
+     * @param string|mixed $items NamedSchema name or object form
      *        of decoded JSON schema representation.
      * @param string $default_namespace namespace of enclosing schema
      * @param NamedSchemata &$schemata
@@ -47,7 +46,7 @@ class ArraySchema extends Schema
 
 
     /**
-     * @returns Name|Schema named schema name or AvroSchema
+     * @returns Name|Schema named schema name or Schema
      *          of this array schema's elements.
      */
     public function items()

--- a/src/Avro/Schema/Field.php
+++ b/src/Avro/Schema/Field.php
@@ -5,7 +5,7 @@ namespace Avro\Schema;
 use Avro\Exception\SchemaParseException;
 
 /**
- * Field of an {@link AvroRecordSchema}
+ * Field of an {@link RecordSchema}
  * @package Avro
  */
 class Field extends Schema
@@ -91,8 +91,8 @@ class Field extends Schema
     private $order;
 
     /**
-     * @var boolean whether or not the AvroNamedSchema of this field is
-     *              defined in the AvroNamedSchemata instance
+     * @var boolean whether or not the NamedSchema of this field is
+     *              defined in the NamedSchemata instance
      */
     private $is_type_from_schemata;
 

--- a/src/Avro/Schema/FixedSchema.php
+++ b/src/Avro/Schema/FixedSchema.php
@@ -5,7 +5,7 @@ namespace Avro\Schema;
 use Avro\Exception\SchemaParseException;
 
 /**
- * AvroNamedSchema with fixed-length data values
+ * NamedSchema with fixed-length data values
  * @package Avro
  */
 class FixedSchema extends NamedSchema
@@ -25,9 +25,10 @@ class FixedSchema extends NamedSchema
     public function __construct(Name $name, $doc, $size, NamedSchemata &$schemata = null)
     {
         $doc = null; // Fixed schemas don't have doc strings.
-        if (!is_integer($size))
+        if (!is_integer($size)) {
             throw new SchemaParseException(
                 'Fixed Schema requires a valid integer for "size" attribute');
+        }
         parent::__construct(Schema::FIXED_SCHEMA, $name, $doc, $schemata);
         return $this->size = $size;
     }

--- a/src/Avro/Schema/MapSchema.php
+++ b/src/Avro/Schema/MapSchema.php
@@ -10,7 +10,7 @@ namespace Avro\Schema;
 class MapSchema extends Schema
 {
     /**
-     * @var string|Schema named schema name or AvroSchema
+     * @var string|Schema named schema name or Schema
      *      of map schema values.
      */
     private $values;

--- a/src/Avro/Schema/Name.php
+++ b/src/Avro/Schema/Name.php
@@ -2,6 +2,8 @@
 
 namespace Avro\Schema;
 
+use Avro\Exception\SchemaParseException;
+
 /**
  * @package Avro
  */
@@ -43,14 +45,14 @@ class Name
     /**
      * @param string $namespace
      * @returns boolean true if namespace is composed of valid names
-     * @throws AvroSchemaParseException if any of the namespace components
+     * @throws SchemaParseException if any of the namespace components
      *                                  are invalid.
      */
     private static function check_namespace_names($namespace)
     {
         foreach (explode(self::NAME_SEPARATOR, $namespace) as $n) {
             if (empty($n) || (0 == preg_match(self::NAME_REGEXP, $n)))
-                throw new AvroSchemaParseException(sprintf('Invalid name "%s"', $n));
+                throw new SchemaParseException(sprintf('Invalid name "%s"', $n));
         }
         return true;
     }
@@ -59,12 +61,12 @@ class Name
      * @param string $name
      * @param string $namespace
      * @returns string
-     * @throws AvroSchemaParseException if any of the names are not valid.
+     * @throws SchemaParseException if any of the names are not valid.
      */
     private static function parse_fullname($name, $namespace)
     {
         if (!is_string($namespace) || empty($namespace))
-            throw new AvroSchemaParseException('Namespace must be a non-empty string.');
+            throw new SchemaParseException('Namespace must be a non-empty string.');
         self::check_namespace_names($namespace);
         return $namespace . '.' . $name;
     }
@@ -96,21 +98,23 @@ class Name
      */
     public function __construct($name, $namespace, $default_namespace)
     {
-        if (!is_string($name) || empty($name))
-            throw new AvroSchemaParseException('Name must be a non-empty string.');
+        if (!is_string($name) || empty($name)) {
+            throw new SchemaParseException('Name must be a non-empty string.');
+        }
 
         if (strpos($name, self::NAME_SEPARATOR)
             && self::check_namespace_names($name)
-        )
+        ) {
             $this->fullname = $name;
-        elseif (0 == preg_match(self::NAME_REGEXP, $name))
-            throw new AvroSchemaParseException(sprintf('Invalid name "%s"', $name));
-        elseif (!is_null($namespace))
+        } elseif (0 == preg_match(self::NAME_REGEXP, $name)) {
+            throw new SchemaParseException(sprintf('Invalid name "%s"', $name));
+        } elseif (!is_null($namespace)) {
             $this->fullname = self::parse_fullname($name, $namespace);
-        elseif (!is_null($default_namespace))
+        } elseif (!is_null($default_namespace)) {
             $this->fullname = self::parse_fullname($name, $default_namespace);
-        else
+        } else {
             $this->fullname = $name;
+        }
 
         list($this->name, $this->namespace) = self::extract_namespace($this->fullname);
         $this->qualified_name = (is_null($this->namespace)

--- a/src/Avro/Schema/NamedSchema.php
+++ b/src/Avro/Schema/NamedSchema.php
@@ -7,7 +7,7 @@ use Avro\Exception\SchemaParseException;
 /**
  * Parent class of named Avro schema
  * @package Avro
- * @todo Refactor AvroNamedSchema to use an AvroName instance
+ * @todo Refactor NamedSchema to use an AvroName instance
  *       to store name information.
  */
 class NamedSchema extends Schema

--- a/src/Avro/Schema/NamedSchemata.php
+++ b/src/Avro/Schema/NamedSchemata.php
@@ -5,7 +5,7 @@ namespace Avro\Schema;
 use Avro\Exception\SchemaParseException;
 
 /**
- *  Keeps track of AvroNamedSchema which have been observed so far,
+ *  Keeps track of NamedSchema which have been observed so far,
  *  as well as the default namespace.
  *
  * @package Avro
@@ -18,7 +18,7 @@ class NamedSchemata
     private $schemata;
 
     /**
-     * @param AvroNamedSchemata []
+     * @param NamedSchemata []
      */
     public function __construct($schemata = array())
     {
@@ -64,20 +64,21 @@ class NamedSchemata
     }
 
     /**
-     * Creates a new AvroNamedSchemata instance of this schemata instance
+     * Creates a new NamedSchemata instance of this schemata instance
      * with the given $schema appended.
-     * @param AvroNamedSchema schema to add to this existing schemata
+     * @param NamedSchema schema to add to this existing schemata
      * @returns NamedSchemata
      */
     public function clone_with_new_schema(NamedSchema $schema)
     {
         $name = $schema->fullname();
-        if (Schema::is_valid_type($name))
+        if (Schema::is_valid_type($name)) {
             throw new SchemaParseException(
                 sprintf('Name "%s" is a reserved type name', $name));
-        else if ($this->has_name($name))
+        } else if ($this->has_name($name)) {
             throw new SchemaParseException(
                 sprintf('Name "%s" is already in use', $name));
+        }
         $schemata = new NamedSchemata($this->schemata);
         $schemata->schemata[$name] = $schema;
         return $schemata;

--- a/src/Avro/Schema/RecordSchema.php
+++ b/src/Avro/Schema/RecordSchema.php
@@ -56,14 +56,14 @@ class RecordSchema extends NamedSchema
     }
 
     /**
-     * @var Schema[] array of AvroNamedSchema field definitions of
-     *                   this AvroRecordSchema
+     * @var Schema[] array of NamedSchema field definitions of
+     *                   this RecordSchema
      */
     private $fields;
 
     /**
      * @var array map of field names to field objects.
-     * @internal Not called directly. Memoization of AvroRecordSchema->fields_hash()
+     * @internal Not called directly. Memoization of RecordSchema->fields_hash()
      */
     private $fields_hash;
 
@@ -79,14 +79,16 @@ class RecordSchema extends NamedSchema
     public function __construct($name, $doc, $fields, NamedSchemata &$schemata = null,
                                 $schema_type = Schema::RECORD_SCHEMA)
     {
-        if (is_null($fields))
+        if (is_null($fields)) {
             throw new SchemaParseException(
                 'Record schema requires a non-empty fields attribute');
+        }
 
-        if (Schema::REQUEST_SCHEMA == $schema_type)
+        if (Schema::REQUEST_SCHEMA == $schema_type) {
             parent::__construct($schema_type, $name);
-        else
+        } else {
             parent::__construct($schema_type, $name, $doc, $schemata);
+        }
 
         list($x, $namespace) = $name->name_and_namespace();
         $this->fields = self::parse_fields($fields, $namespace, $schemata);
@@ -112,7 +114,7 @@ class RecordSchema extends NamedSchema
     }
 
     /**
-     * @returns array the schema definitions of the fields of this AvroRecordSchema
+     * @returns array the schema definitions of the fields of this RecordSchema
      */
     public function fields()
     {
@@ -120,7 +122,7 @@ class RecordSchema extends NamedSchema
     }
 
     /**
-     * @returns array a hash table of the fields of this AvroRecordSchema fields
+     * @returns array a hash table of the fields of this RecordSchema fields
      *          keyed by each field's name
      */
     public function fields_hash()

--- a/src/Avro/Schema/Schema.php
+++ b/src/Avro/Schema/Schema.php
@@ -404,7 +404,7 @@ class Schema
 
     /**
      * @internal Should only be called from within the constructor of
-     *           a class which extends AvroSchema
+     *           a class which extends Schema
      * @param string $type a schema type name
      */
     public function __construct($type)


### PR DESCRIPTION
…rt-hand if...else with no braces

made the README.md PHP example a little less messy to read
fixed some class names which were still prepended with Avro... and comments matching Avro[a-zA-Z]+
fixed some shorthand if...else notations which don't use braces which were noticed while fixing redundant class names