### PR TITLE
protocol: Fix compatibility with PHP 7.4

### DIFF
--- a/src/Avro/Protocol/Protocol.php
+++ b/src/Avro/Protocol/Protocol.php
@@ -40,7 +40,7 @@ class Protocol
         if (!is_null($avro["messages"])) {
             foreach ($avro["messages"] as $messageName => $messageAvro) {
                 $message = new ProtocolMessage($messageName, $messageAvro, $this);
-                $this->messages{$messageName} = $message;
+                $this->messages[$messageName] = $message;
             }
         }
     }

--- a/src/Avro/Protocol/ProtocolMessage.php
+++ b/src/Avro/Protocol/ProtocolMessage.php
@@ -19,12 +19,12 @@ class ProtocolMessage
     public function __construct($name, $avro, Protocol $protocol)
     {
         $this->name = $name;
-        $this->request = new RecordSchema(new Name($name, null, $protocol->namespace), null, $avro{'request'}, $protocol->schemata, Schema::REQUEST_SCHEMA);
+        $this->request = new RecordSchema(new Name($name, null, $protocol->namespace), null, $avro['request'], $protocol->schemata, Schema::REQUEST_SCHEMA);
 
         if (array_key_exists('response', $avro)) {
-            $this->response = $protocol->schemata->schema_by_name(new Name($avro{'response'}, $protocol->namespace, $protocol->namespace));
+            $this->response = $protocol->schemata->schema_by_name(new Name($avro['response'], $protocol->namespace, $protocol->namespace));
             if ($this->response == null)
-                $this->response = new PrimitiveSchema($avro{'response'});
+                $this->response = new PrimitiveSchema($avro['response']);
         }
     }
 }


### PR DESCRIPTION
The PHP 7.4 release has deprecated[1] accessing array items using the legacy
curly brace syntax (i.e. "$array{'item'}". This syntax now results in a
deprecation warning (E_DEPRECATED). This patch updates the avro library to
consistently use the square brackets syntax (i.e. "$array['item']") when
accessing array elements to avoid the warning.

---
[1] https://wiki.php.net/rfc/deprecate_curly_braces_array_access

Bug: T233012
Change-Id: Ida7a76cd7896313abd39f7d556f4b9640cd8da59